### PR TITLE
Compatibility, and Buffs

### DIFF
--- a/1.3/Defs/FactionDefs/Faction_UAC.xml
+++ b/1.3/Defs/FactionDefs/Faction_UAC.xml
@@ -88,6 +88,18 @@ Either the UAC is here to clean up a mess they made, or worse, they are about to
         </options>
       </li>
       <li>
+        <kindDef>Peaceful</kindDef>
+        <options>
+          <UAC_Agent>100</UAC_Agent>
+          <UAC_Scientist>100</UAC_Scientist>
+          <UAC_Wildcat>50</UAC_Wildcat>
+          <UAC_Sheperd>50</UAC_Sheperd>
+          <UAC_Raven>50</UAC_Raven>
+          <UAC_ASP>50</UAC_ASP>
+          <UAC_XO>10</UAC_XO>
+        </options>
+      </li>
+      <li>
         <kindDef>Trader</kindDef>
         <traders>
           <UAC_Trader>1</UAC_Trader>

--- a/1.3/Defs/PawnkindDefs/PawnKinds_SpaceMarines.xml
+++ b/1.3/Defs/PawnkindDefs/PawnKinds_SpaceMarines.xml
@@ -119,14 +119,6 @@
     <weaponTags>
       <li>MarineMelee</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -146,6 +138,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~20</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>12~20</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>7~15</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <!-- ============================================== -->
   <PawnKindDef>
@@ -186,14 +213,6 @@
     <weaponTags>
       <li>MarineLight</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -213,6 +232,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~20</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>12~20</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>7~15</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <!-- ============================================== -->
   <PawnKindDef>
@@ -253,14 +307,6 @@
     <weaponTags>
       <li>MarineHeavy</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -280,6 +326,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~20</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>12~20</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>7~15</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <!-- ============================================== -->
   <PawnKindDef>
@@ -322,14 +403,6 @@
     <weaponTags>
       <li>MarineSniper</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -349,6 +422,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~20</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>12~20</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>7~15</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <!-- ============================================== -->
   <PawnKindDef>
@@ -391,14 +499,6 @@
     <weaponTags>
       <li>UAC_XO</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -418,5 +518,40 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>15~20</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>16~20</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>10~15</range>
+		</li> 
+    </skills>
   </PawnKindDef>
 </Defs>

--- a/1.3/Defs/PawnkindDefs/PawnKinds_UAC.xml
+++ b/1.3/Defs/PawnkindDefs/PawnKinds_UAC.xml
@@ -55,6 +55,9 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+    </techHediffsRequired>
   </PawnKindDef>
   <PawnKindDef ParentName="UAC_FBase">
     <defName>UAC_Trader</defName>
@@ -185,14 +188,6 @@
     <weaponTags>
       <li>UAC_Wildcat</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>3000</min>
-      <max>9000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -212,6 +207,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>8~15</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>8~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~10</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <PawnKindDef>
     <defName>UAC_Sheperd</defName>
@@ -250,14 +280,6 @@
     <weaponTags>
       <li>UAC_Sheperd</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>3200</min>
-      <max>9400</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -277,6 +299,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>8~15</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>8~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~10</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <PawnKindDef>
     <defName>UAC_Raven</defName>
@@ -315,14 +372,6 @@
     <weaponTags>
       <li>UAC_Raven</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>1200</min>
-      <max>9000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbioniceye</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -342,6 +391,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>8~15</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>8~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~10</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <PawnKindDef>
     <defName>UAC_ASP</defName>
@@ -380,14 +464,6 @@
     <weaponTags>
       <li>UAC_ASP</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>1200</min>
-      <max>8400</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -407,6 +483,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>8~15</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>8~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~10</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <PawnKindDef>
     <defName>UAC_XO</defName>
@@ -444,14 +555,6 @@
       <li>Apparel_UACCsuit</li>
       <li>Apparel_UACVIPSuit</li>
     </apparelRequired>
-    <techHediffsMoney>
-      <min>1000</min>
-      <max>5000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.55</skipChance>
       <subOptionsChooseOne>
@@ -471,5 +574,40 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~15</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>12~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>10~16</range>
+		</li> 
+    </skills>
   </PawnKindDef>
 </Defs>

--- a/1.3/Defs/PawnkindDefs/PawnKinds_UACSpecOp.xml
+++ b/1.3/Defs/PawnkindDefs/PawnKinds_UACSpecOp.xml
@@ -51,14 +51,6 @@
     <weaponTags>
       <li>UAC_EliteLight</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -78,6 +70,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~16</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>11~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~12</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <!-- ============================================== -->
   <PawnKindDef>
@@ -124,14 +151,6 @@
     <weaponTags>
       <li>UAC_EliteSniper</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -151,6 +170,41 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~16</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>11~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~12</range>
+		</li> 
+    </skills>
   </PawnKindDef>
   <!-- ============================================== -->
   <PawnKindDef>
@@ -197,14 +251,6 @@
     <weaponTags>
       <li>UAC_EliteHeavy</li>
     </weaponTags>
-    <techHediffsMoney>
-      <min>4000</min>
-      <max>20000</max>
-    </techHediffsMoney>
-    <techHediffsChance>1</techHediffsChance>
-    <techHediffsTags>
-      <li>UACbionicspine</li>
-    </techHediffsTags>
     <inventoryOptions>
       <skipChance>0.01</skipChance>
       <subOptionsChooseOne>
@@ -224,5 +270,40 @@
         </li>
       </subOptionsChooseOne>
     </inventoryOptions>
+	<!-- Buffs -->
+    <techHediffsRequired>
+		<li>DeathAcidifier</li>
+		<li>UACbionicspine</li>
+		<li>UACbioniceye</li>
+		<li>UACbioniceye</li>
+		<li>UACCombatImplant</li>
+		<li>UACSyntheticLung</li>
+		<li>UACSyntheticHeart</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticArm</li>
+		<li>UACSyntheticLeg</li>
+		<li>UACSyntheticLeg</li>
+    </techHediffsRequired>
+    <biocodeWeaponChance>1</biocodeWeaponChance>
+    <forcedTraits>
+		<li>Tough</li>
+    </forcedTraits>
+    <disallowedTraits>
+		<li>Wimp</li>
+    </disallowedTraits>
+	<skills>
+		<li>
+			<skill>Shooting</skill>
+			<range>12~16</range>
+		</li>
+		<li>
+			<skill>Melee</skill>
+			<range>11~16</range>
+		</li>	  
+		<li>
+			<skill>Social</skill>
+			<range>5~12</range>
+		</li> 
+    </skills>
   </PawnKindDef>
 </Defs>


### PR DESCRIPTION
## Faction_UAC.xml

- Added a Peaceful group for Hospitality Compatibility

## Pawnkinds

Turned the Marines into a more end-game faction
- Buffed their combatants to have at least 10 in melee and shooting
- Forced them to have biocoded weapons
- Forced Tough trait, disallowed Wimp
- Forced several bionics
- Removed chance for random bionic Hediffs