### PR TITLE
Apparel Tag Render Update

### DIFF
--- a/1.5/Defs/ThingDefs_Misc/Apparel_UACApparel.xml
+++ b/1.5/Defs/ThingDefs_Misc/Apparel_UACApparel.xml
@@ -624,6 +624,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>
@@ -681,6 +684,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>
@@ -738,6 +744,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>
@@ -795,6 +804,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>
@@ -848,6 +860,7 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>Eyes</li>
       </bodyPartGroups>
@@ -904,6 +917,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>

--- a/1.5/Defs/ThingDefs_SpaceMarines/Apparel_DOOMApparel.xml
+++ b/1.5/Defs/ThingDefs_SpaceMarines/Apparel_DOOMApparel.xml
@@ -105,6 +105,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>
@@ -162,6 +165,9 @@
     </statBases>
     <generateCommonality>0.3</generateCommonality>
     <apparel>
+      <parentTagDef>ApparelHead</parentTagDef>
+      <shellRenderedBehindHead>false</shellRenderedBehindHead>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>


### PR DESCRIPTION
## Changes
- Additional subtags on apparel tag for head-related apparel in 1.5.

## Reasoning
- Changes for apparel rendering in 1.5 caused the former helmet-related apparel with missing tags to render on the Torso part.

## Testing
Check tests you have performed : 
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended ingame.)